### PR TITLE
Fix audit log repository query methods

### DIFF
--- a/src/main/kotlin/demo/incident/repository/IncidentAuditLogRepository.kt
+++ b/src/main/kotlin/demo/incident/repository/IncidentAuditLogRepository.kt
@@ -5,6 +5,6 @@ import org.springframework.data.domain.Sort
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface IncidentAuditLogRepository : JpaRepository<IncidentAuditLog, Long> {
-    fun findByIncidentId(incidentId: Long, sort: Sort): List<IncidentAuditLog>
-    fun existsByIncidentId(incidentId: Long): Boolean
+    fun findByIncident_Id(incidentId: Long, sort: Sort): List<IncidentAuditLog>
+    fun existsByIncident_Id(incidentId: Long): Boolean
 }

--- a/src/main/kotlin/demo/incident/service/IncidentAuditLogService.kt
+++ b/src/main/kotlin/demo/incident/service/IncidentAuditLogService.kt
@@ -11,10 +11,10 @@ class IncidentAuditLogService(
     private val auditRepo: IncidentAuditLogRepository
 ) {
     fun getAuditLog(incidentId: Long, direction: Sort.Direction): List<IncidentAuditLogResponse> {
-        if (!auditRepo.existsByIncidentId(incidentId)) {
+        if (!auditRepo.existsByIncident_Id(incidentId)) {
             throw IllegalArgumentException("Incident $incidentId not found")
         }
         val sort = Sort.by(direction, "changedAt")
-        return auditRepo.findByIncidentId(incidentId, sort).map { it.toResponseDto() }
+        return auditRepo.findByIncident_Id(incidentId, sort).map { it.toResponseDto() }
     }
 }


### PR DESCRIPTION
## Summary
- fix incorrect method names in `IncidentAuditLogRepository`
- update `IncidentAuditLogService` to use the new names

## Testing
- `./gradlew test` *(fails: No route to host)*