### PR TITLE
Add functional tests for controllers

### DIFF
--- a/src/test/kotlin/demo/hello/controller/HelloControllerTest.kt
+++ b/src/test/kotlin/demo/hello/controller/HelloControllerTest.kt
@@ -1,0 +1,24 @@
+package demo.hello.controller
+
+import demo.RestExceptionHandler
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+
+class HelloControllerTest : StringSpec({
+
+    val mockMvc: MockMvc = MockMvcBuilders.standaloneSetup(HelloController())
+        .setControllerAdvice(RestExceptionHandler())
+        .build()
+
+    "should return hello world message" {
+        val result = mockMvc.perform(get("/api/hello"))
+            .andExpect(status().isOk)
+            .andReturn()
+
+        result.response.contentAsString shouldBe "Hello World! This is the Incident-Demo!"
+    }
+})

--- a/src/test/kotlin/demo/incident/controller/IncidentAuditLogControllerTest.kt
+++ b/src/test/kotlin/demo/incident/controller/IncidentAuditLogControllerTest.kt
@@ -1,0 +1,41 @@
+package demo.incident.controller
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import demo.RestExceptionHandler
+import demo.incident.dto.api.IncidentAuditLogResponse
+import demo.incident.service.IncidentAuditLogService
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.springframework.data.domain.Sort
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.time.LocalDateTime
+
+class IncidentAuditLogControllerTest : StringSpec({
+
+    val service = mockk<IncidentAuditLogService>()
+    val objectMapper = jacksonObjectMapper()
+    val mockMvc: MockMvc = MockMvcBuilders.standaloneSetup(IncidentAuditLogController(service))
+        .setControllerAdvice(RestExceptionHandler())
+        .build()
+
+    "should return audit log for incident" {
+        val response = listOf(
+            IncidentAuditLogResponse(1L, "OPEN", "RESOLVED", LocalDateTime.now())
+        )
+        every { service.getAuditLog(42L, Sort.Direction.ASC) } returns response
+
+        val result = mockMvc.perform(get("/api/incidents/42/audit?direction=ASC"))
+            .andExpect(status().isOk)
+            .andReturn()
+
+        verify { service.getAuditLog(42L, Sort.Direction.ASC) }
+        val body = objectMapper.readValue(result.response.contentAsString, Array<IncidentAuditLogResponse>::class.java).toList()
+        body shouldContainExactly response
+    }
+})

--- a/src/test/kotlin/demo/incident/controller/IncidentControllerTest.kt
+++ b/src/test/kotlin/demo/incident/controller/IncidentControllerTest.kt
@@ -1,0 +1,108 @@
+package demo.incident.controller
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import demo.RestExceptionHandler
+import demo.incident.dto.api.IncidentRequest
+import demo.incident.dto.api.IncidentResponse
+import demo.incident.dto.api.IncidentStatusUpdate
+import demo.incident.model.IncidentSeverity
+import demo.incident.model.IncidentStatus
+import demo.incident.model.IncidentType
+import demo.incident.service.IncidentService
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.springframework.data.domain.PageImpl
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.time.LocalDateTime
+
+class IncidentControllerTest : StringSpec({
+
+    val service = mockk<IncidentService>()
+    val objectMapper = jacksonObjectMapper()
+    val mockMvc: MockMvc = MockMvcBuilders.standaloneSetup(IncidentController(service))
+        .setControllerAdvice(RestExceptionHandler())
+        .build()
+
+    "should create incident via POST" {
+        val request = IncidentRequest(
+            title = "Test",
+            description = "Desc",
+            type = IncidentType.AUDIT_FINDING,
+            severity = IncidentSeverity.HIGH
+        )
+        val response = IncidentResponse(
+            id = 1L,
+            title = request.title,
+            description = request.description,
+            type = request.type.name,
+            severity = request.severity.name,
+            status = IncidentStatus.OPEN,
+            createdAt = LocalDateTime.now(),
+            updatedAt = LocalDateTime.now()
+        )
+        every { service.createIncident(request) } returns response
+
+        val result = mockMvc.perform(
+            post("/api/incidents")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        )
+            .andExpect(status().isOk)
+            .andReturn()
+
+        verify { service.createIncident(request) }
+        objectMapper.readValue(result.response.contentAsString, IncidentResponse::class.java) shouldBe response
+    }
+
+    "should search incidents via GET" {
+        val response = IncidentResponse(
+            id = 1L,
+            title = "t",
+            description = "d",
+            type = IncidentType.AUDIT_FINDING.name,
+            severity = IncidentSeverity.HIGH.name,
+            status = IncidentStatus.OPEN,
+            createdAt = LocalDateTime.now(),
+            updatedAt = LocalDateTime.now()
+        )
+        every { service.search(any()) } returns PageImpl(listOf(response))
+
+        mockMvc.perform(get("/api/incidents"))
+            .andExpect(status().isOk)
+
+        verify { service.search(any()) }
+    }
+
+    "should update status via PATCH" {
+        val update = IncidentStatusUpdate(IncidentStatus.RESOLVED)
+        val response = IncidentResponse(
+            id = 1L,
+            title = "t",
+            description = "d",
+            type = IncidentType.AUDIT_FINDING.name,
+            severity = IncidentSeverity.HIGH.name,
+            status = update.status,
+            createdAt = LocalDateTime.now(),
+            updatedAt = LocalDateTime.now()
+        )
+        every { service.updateStatus(1L, update) } returns response
+
+        mockMvc.perform(
+            patch("/api/incidents/1/status")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(update))
+        )
+            .andExpect(status().isOk)
+
+        verify { service.updateStatus(1L, update) }
+    }
+})


### PR DESCRIPTION
## Summary
- add HelloControllerTest verifying simple hello endpoint
- add IncidentControllerTest covering create, search, and update status endpoints
- add IncidentAuditLogControllerTest for audit log retrieval

## Testing
- `./gradlew test --no-daemon` *(fails: No route to host)*