### PR TITLE
Fix audit log timestamp

### DIFF
--- a/src/main/kotlin/demo/incident/kafka/IncidentEventConsumer.kt
+++ b/src/main/kotlin/demo/incident/kafka/IncidentEventConsumer.kt
@@ -30,7 +30,8 @@ class IncidentEventConsumer(
         val logEntry = IncidentAuditLog(
             incident = incident,
             oldStatus = event.oldStatus.name,
-            newStatus = event.newStatus.name
+            newStatus = event.newStatus.name,
+            changedAt = event.changedAt
         )
         auditRepo.save(logEntry)
     }

--- a/src/main/kotlin/demo/incident/repository/IncidentAuditLogRepository.kt
+++ b/src/main/kotlin/demo/incident/repository/IncidentAuditLogRepository.kt
@@ -5,6 +5,6 @@ import org.springframework.data.domain.Sort
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface IncidentAuditLogRepository : JpaRepository<IncidentAuditLog, Long> {
-    fun findByIncidentId(incidentId: Long, sort: Sort): List<IncidentAuditLog>
-    fun existsByIncidentId(incidentId: Long): Boolean
+    fun findByIncident_Id(incidentId: Long, sort: Sort): List<IncidentAuditLog>
+    fun existsByIncident_Id(incidentId: Long): Boolean
 }

--- a/src/main/kotlin/demo/incident/service/IncidentAuditLogService.kt
+++ b/src/main/kotlin/demo/incident/service/IncidentAuditLogService.kt
@@ -11,10 +11,10 @@ class IncidentAuditLogService(
     private val auditRepo: IncidentAuditLogRepository
 ) {
     fun getAuditLog(incidentId: Long, direction: Sort.Direction): List<IncidentAuditLogResponse> {
-        if (!auditRepo.existsByIncidentId(incidentId)) {
+        if (!auditRepo.existsByIncident_Id(incidentId)) {
             throw IllegalArgumentException("Incident $incidentId not found")
         }
         val sort = Sort.by(direction, "changedAt")
-        return auditRepo.findByIncidentId(incidentId, sort).map { it.toResponseDto() }
+        return auditRepo.findByIncident_Id(incidentId, sort).map { it.toResponseDto() }
     }
 }

--- a/src/test/kotlin/demo/incident/kafka/IncidentEventConsumerTest.kt
+++ b/src/test/kotlin/demo/incident/kafka/IncidentEventConsumerTest.kt
@@ -51,5 +51,6 @@ class IncidentEventConsumerTest : StringSpec({
         slot.captured.incident shouldBe incident
         slot.captured.oldStatus shouldBe "OPEN"
         slot.captured.newStatus shouldBe "RESOLVED"
+        slot.captured.changedAt shouldBe event.changedAt
     }
 })


### PR DESCRIPTION
## Summary
- use event timestamp in `IncidentEventConsumer`
- verify timestamp is logged correctly in the consumer unit test

## Testing
- `./gradlew test` *(fails: No route to host)*