### PR TITLE
Add workflow for Kotest backend tests

### DIFF
--- a/.github/workflows/kotest.yml
+++ b/.github/workflows/kotest.yml
@@ -1,0 +1,30 @@
+name: Backend Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Cache Gradle packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: Run tests
+        run: ./gradlew test --no-daemon


### PR DESCRIPTION
## Summary
- run backend tests on GitHub Actions with Java 21

## Testing
- `./gradlew test` *(fails: NoRouteToHostException)*